### PR TITLE
Switch to semver module

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,16 +14,15 @@
     "release": "./bin/npm-prepublish.js --verbose && npm publish && git checkout package.json"
   },
   "dependencies": {
-    "semversionizer-parser": "git://github.com/orangemug/semversionizer-parser.git#v0.2.0",
-    "semversionizer-comparison": "git://github.com/orangemug/semversionizer-comparison.git#v0.2.0",
     "denodeify": "^1.2.0",
     "es6-promise": "^2.0.1",
     "jsonfile": "^2.0.0",
     "minimist": "^1.1.0",
+    "semver": "^5.3.0",
     "winston": "^0.8.3"
   },
   "devDependencies": {
     "jshint": "^2.5.11",
-    "lintspaces-cli": "0.0.4"
+    "lintspaces-cli": "^0.4.0"
   }
 }


### PR DESCRIPTION
Fixes #2 

I was getting installation errors from this package due to the two github semver repositories used as dependencies. I figured I would replace them with the [semver](https://www.npmjs.com/semver) module used by npm.

<details><summary>

This is what I see if you run `npm i` on master</summary>



``` bash
npm ERR! git clone --template=/Users/jake.champion/.npm/_git-remotes/_templates --mirror git://github.com/orangemug/semversionizer-parser.git /Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-parser-git-v0-2-0-583c3909: Cloning into bare repository '/Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-parser-git-v0-2-0-583c3909'...
npm ERR! git clone --template=/Users/jake.champion/.npm/_git-remotes/_templates --mirror git://github.com/orangemug/semversionizer-parser.git /Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-parser-git-v0-2-0-583c3909: fatal: unable to connect to github.com:
npm ERR! git clone --template=/Users/jake.champion/.npm/_git-remotes/_templates --mirror git://github.com/orangemug/semversionizer-parser.git /Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-parser-git-v0-2-0-583c3909: github.com[0: 192.30.253.113]: errno=Connection refused
npm ERR! git clone --template=/Users/jake.champion/.npm/_git-remotes/_templates --mirror git://github.com/orangemug/semversionizer-comparison.git /Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-comparison-git-v0-2-0-522eb72a: Cloning into bare repository '/Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-comparison-git-v0-2-0-522eb72a'...
npm ERR! git clone --template=/Users/jake.champion/.npm/_git-remotes/_templates --mirror git://github.com/orangemug/semversionizer-comparison.git /Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-comparison-git-v0-2-0-522eb72a: fatal: unable to connect to github.com:
npm ERR! git clone --template=/Users/jake.champion/.npm/_git-remotes/_templates --mirror git://github.com/orangemug/semversionizer-comparison.git /Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-comparison-git-v0-2-0-522eb72a: github.com[0: 192.30.253.113]: errno=Connection refused
npm ERR! Darwin 15.6.0
npm ERR! argv "/Users/jake.champion/.nvm/versions/node/v6.6.0/bin/node" "/Users/jake.champion/.nvm/versions/node/v6.6.0/bin/npm" "i"
npm ERR! node v6.6.0
npm ERR! npm  v3.10.3
npm ERR! code 128

npm ERR! Command failed: git clone --template=/Users/jake.champion/.npm/_git-remotes/_templates --mirror git://github.com/orangemug/semversionizer-parser.git /Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-parser-git-v0-2-0-583c3909
npm ERR! Cloning into bare repository '/Users/jake.champion/.npm/_git-remotes/git-github-com-orangemug-semversionizer-parser-git-v0-2-0-583c3909'...
npm ERR! fatal: unable to connect to github.com:
npm ERR! github.com[0: 192.30.253.113]: errno=Connection refused
npm ERR!
npm ERR!
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/jake.champion/Code/work/next/npm-prepublish/npm-debug.log
```

</details>
